### PR TITLE
[source-refactor] More flexible SNAGSBY_SOURCE parsing

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"net/url"
 	"regexp"
+	"strings"
 )
 
-var commaSplit = regexp.MustCompile(`\s*,\s*`)
+var commaSplit = regexp.MustCompile(`[\s|,]+`)
 
 // Config is the main configuration object
 type Config struct {
@@ -19,7 +20,7 @@ func NewConfig() *Config {
 }
 
 func splitEnvArg(envArg string) []string {
-	return commaSplit.Split(envArg, -1)
+	return commaSplit.Split(strings.TrimSpace(envArg), -1)
 }
 
 // SetSources will set the internal sources slice from a list of strings or
@@ -29,7 +30,7 @@ func (c *Config) SetSources(args []string, env string) ([]*url.URL, error) {
 	var urls []*url.URL
 
 	if len(args) == 0 && env == "" {
-		return urls, errors.New("Bad")
+		return urls, errors.New("No source provided")
 	}
 
 	if len(args) > 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -13,6 +13,18 @@ func TestSplitEnvArg(t *testing.T) {
 	if o[1] != "Dickens" {
 		t.Fail()
 	}
+	spacedString := splitEnvArg("Charles     Dickens")
+	if spacedString[0] != "Charles" {
+		t.Errorf("Expecting Charles got %s", spacedString)
+	}
+
+	if v := splitEnvArg(" charles  dickens"); v[0] != "charles" {
+		t.Errorf("Expected charles got %s", v)
+	}
+
+	if v := splitEnvArg(" charles  "); v[0] != "charles" {
+		t.Errorf("Expected charles got %s", v)
+	}
 }
 
 func TestNew(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // VERSION - snagsby version
-const VERSION = "0.1.0"
+const VERSION = "0.1.1"


### PR DESCRIPTION
This will allow more flexible parsing of the `SNAGSBY_SOURCE` env var. Things like

``` bash
export SNAGSBY_SOURCE="  s3://my-bucket/config.json,  s3://my-bucket/config2.json  s3://other-bucket/config3.json  "
```
