### PR TITLE
[aws-sdk-version] Expose the aws sdk version used to compile

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/roverdotcom/snagsby/secrets"
 )
 
@@ -26,7 +27,7 @@ func main() {
 	flagSet.Parse(os.Args[1:])
 
 	if showVersion {
-		fmt.Printf("snagsby version %s\n", VERSION)
+		fmt.Printf("snagsby version %s (aws sdk: %s)\n", VERSION, aws.SDKVersion)
 		return
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // VERSION - snagsby version
-const VERSION = "0.1.2"
+const VERSION = "0.1.3"


### PR DESCRIPTION
Show the aws sdk version snagsby was compiled against in the version output.
