### PR TITLE
S3 keys work differently in v2

### DIFF
--- a/pkg/resolvers/s3_test.go
+++ b/pkg/resolvers/s3_test.go
@@ -1,0 +1,21 @@
+package resolvers
+
+import "testing"
+
+func TestSanitizeKey(t *testing.T) {
+	s := S3ManagerResolver{}
+	values := [][]string{
+		{"test/value", "test/value"},
+		{"/test/value", "test/value"},
+		{"//test/value", "/test/value"},
+	}
+
+	for _, value := range values {
+		input := value[0]
+		expected := value[1]
+		actual := s.SanitizeKey(value[0])
+		if actual != expected {
+			t.Errorf("Input %s, expected %s, but got %s", input, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
S3 Keys work differently in AWS v2. We need to strip the first trailing slash.