### PR TITLE
[DEV-116267] Point Dockerfiles to ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_VERSION
-FROM golang:${GOLANG_VERSION:-1.15.6} as build
+FROM 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/golang:${GOLANG_VERSION:-1.15.6} as build
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/roverdotcom/snagsby
 COPY . /go/src/github.com/roverdotcom/snagsby
@@ -8,7 +8,7 @@ RUN /go/src/github.com/roverdotcom/snagsby/snagsby -v
 
 
 # Image with more tools installed and no entrypoint
-FROM alpine:3 as dev
+FROM 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/alpine:3 as dev
 WORKDIR /app/
 RUN apk add --no-cache \
     ca-certificates \
@@ -17,7 +17,7 @@ RUN apk add --no-cache \
 COPY --from=build /go/src/github.com/roverdotcom/snagsby/snagsby /app/snagsby
 
 
-FROM alpine:3
+FROM 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/alpine:3
 WORKDIR /app/
 RUN apk add --no-cache \
     ca-certificates


### PR DESCRIPTION
Updating Dockerfiles to point to ECR as part of migration away from Dockerhub to ECR.

```
➜  snagsby git:(DEV-116267) docker build .          
[+] Building 0.0s (0/1)                                                                                                                                                                                                                                                                                                                                                                   docker:rancher-desktop
[+] Building 54.8s (16/16) FINISHED                                                                                                                                                                                                                                                                                                                                                       docker:rancher-desktop
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 955B                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/alpine:3                                                                                                                                                                                                                                                                                            0.7s
 => [internal] load metadata for 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/golang:1.16.3                                                                                                                                                                                                                                                                                       5.3s
 => [auth] sharing credentials for 290268990387.dkr.ecr.us-west-2.amazonaws.com                                                                                                                                                                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                                           0.0s
 => => transferring context: 82B                                                                                                                                                                                                                                                                                                                                                                            0.0s
 => [build 1/5] FROM 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/golang:1.16.3@sha256:f7d3519759ba6988a2b73b5874b17c5958ac7d0aa48a8b1d84d66ef25fa345f1                                                                                                                                                                                                                          43.3s
 => => resolve 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/golang:1.16.3@sha256:f7d3519759ba6988a2b73b5874b17c5958ac7d0aa48a8b1d84d66ef25fa345f1                                                                                                                                                                                                                                 0.0s
 => => sha256:8795bd287342f73e249883cd2e19da16b13c16a4bbeb9230910d6f6e490f506e 1.79kB / 1.79kB                                                                                                                                                                                                                                                                                                              0.0s
 => => sha256:c667eb56cd05909001c1c50e81cbc75e290fd8e353f974bab4246a0d4fc484ca 7.70MB / 7.70MB                                                                                                                                                                                                                                                                                                              5.3s
 => => sha256:27ca15a4cef673e0e1a7bc3e659f4653df9bce82b945e367475e436852cc7880 9.98MB / 9.98MB                                                                                                                                                                                                                                                                                                              5.7s
 => => sha256:f7d3519759ba6988a2b73b5874b17c5958ac7d0aa48a8b1d84d66ef25fa345f1 2.36kB / 2.36kB                                                                                                                                                                                                                                                                                                              0.0s
 => => sha256:cc20ce841dfaa1ef481638a809e7e43f5acd2ab037e7631c8c4cce27488248c3 7.00kB / 7.00kB                                                                                                                                                                                                                                                                                                              0.0s
 => => sha256:01cf0f0da10ede0eec0fc1c5fbfdeb63a447dfcc0a3c4419c0a4c3f0a2826636 49.23MB / 49.23MB                                                                                                                                                                                                                                                                                                            3.7s
 => => extracting sha256:01cf0f0da10ede0eec0fc1c5fbfdeb63a447dfcc0a3c4419c0a4c3f0a2826636                                                                                                                                                                                                                                                                                                                   2.0s
 => => sha256:6b7f1cf823a7fca9771e278355d8924fac8d9cef1f8e3ecbc87332c4859d1d4f 52.17MB / 52.17MB                                                                                                                                                                                                                                                                                                           20.8s
 => => sha256:badf929bd8bb50d8e53c0eab7e09c081b2364f11af58c9928959f2f50994fb5f 62.60MB / 62.60MB                                                                                                                                                                                                                                                                                                           37.1s
 => => sha256:fa799477d3e2195276e96437eb2969a5343e97c23ba1b8cddaaa4ed3dd538998 99.60MB / 99.60MB                                                                                                                                                                                                                                                                                                           33.0s
 => => extracting sha256:c667eb56cd05909001c1c50e81cbc75e290fd8e353f974bab4246a0d4fc484ca                                                                                                                                                                                                                                                                                                                   0.2s
 => => extracting sha256:27ca15a4cef673e0e1a7bc3e659f4653df9bce82b945e367475e436852cc7880                                                                                                                                                                                                                                                                                                                   0.2s
 => => extracting sha256:6b7f1cf823a7fca9771e278355d8924fac8d9cef1f8e3ecbc87332c4859d1d4f                                                                                                                                                                                                                                                                                                                   2.2s
 => => sha256:333d6a287c41f7b4d2d6e7fce9f14b675d931350d6d723d76a19cc6bb110bad8 156B / 156B                                                                                                                                                                                                                                                                                                                 21.2s
 => => extracting sha256:badf929bd8bb50d8e53c0eab7e09c081b2364f11af58c9928959f2f50994fb5f                                                                                                                                                                                                                                                                                                                   1.9s
 => => extracting sha256:fa799477d3e2195276e96437eb2969a5343e97c23ba1b8cddaaa4ed3dd538998                                                                                                                                                                                                                                                                                                                   4.0s
 => => extracting sha256:333d6a287c41f7b4d2d6e7fce9f14b675d931350d6d723d76a19cc6bb110bad8                                                                                                                                                                                                                                                                                                                   0.0s
 => [stage-2 1/4] FROM 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/alpine:3@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a                                                                                                                                                                                                                              0.0s
 => CACHED [stage-2 2/4] WORKDIR /app/                                                                                                                                                                                                                                                                                                                                                                      0.0s
 => CACHED [stage-2 3/4] RUN apk add --no-cache     ca-certificates                                                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                                                           0.0s
 => => transferring context: 92.26kB                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => [build 2/5] WORKDIR /go/src/github.com/roverdotcom/snagsby                                                                                                                                                                                                                                                                                                                                              0.1s
 => [build 3/5] COPY . /go/src/github.com/roverdotcom/snagsby                                                                                                                                                                                                                                                                                                                                               0.1s
 => [build 4/5] RUN make build                                                                                                                                                                                                                                                                                                                                                                              5.4s
 => [build 5/5] RUN /go/src/github.com/roverdotcom/snagsby/snagsby -v                                                                                                                                                                                                                                                                                                                                       0.3s
 => [stage-2 4/4] COPY --from=build /go/src/github.com/roverdotcom/snagsby/snagsby /app/snagsby                                                                                                                                                                                                                                                                                                             0.1s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                                                     0.0s
 => => writing image sha256:221a71065bb53f6a501c9221cb69bebd0d0f1b717affb86e482093e0e76ccab9                  
```